### PR TITLE
Feature/Containerize django app

### DIFF
--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -1,0 +1,4 @@
+.env*
+venv
+.dockerignore
+Dockerfile

--- a/app/.env.dev
+++ b/app/.env.dev
@@ -1,0 +1,3 @@
+DEBUG=1
+SECRET_KEY=foo
+DJANGO_ALLOWED_HOSTS=localhost, 127.0.0.1, 0.0.0.0, [::1]

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11.2-slim-buster
+
+WORKDIR /usr/src/app
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+RUN pip install --upgrade pip
+COPY ./requirements.txt .
+RUN pip install -r requirements.txt
+
+# Keep the files that frequently change towards the end of the Dockerfile to harness
+# layers' caching and minimize cache invalidation.
+COPY . .

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -12,6 +12,8 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 
 from pathlib import Path
 
+from decouple import config, Csv
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -20,12 +22,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-po)gb69#7z1rs2h(cjfpexjrtirff)l^+g7n7u1o0tr(^8$%as'
+SECRET_KEY = config('SECRET_KEY', default='django-insecure-po)gb69#7z1rs2h(cjfpexjrtirff)l^+g7n7u1o0tr(^8$%as')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = config('DEBUG', default=False, cast=bool)
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = config('DJANGO_ALLOWED_HOSTS', default='127.0.0.1', cast=Csv())
 
 
 # Application definition

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,5 +1,6 @@
 asgiref==3.6.0
 Django==4.2.1
 djangorestframework==3.14.0
+python-decouple==3.8
 pytz==2023.3
 sqlparse==0.4.4

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: '3.8'
+
+services:
+  products-api:
+    build: ./app
+    command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - ./app/:/usr/src/app/
+    ports:
+      - 8009:8000
+    env_file:
+      - ./app/.env.dev


### PR DESCRIPTION
- Create a dev `Dockerfile` for the products' API.
- Create a `docker-compose.yaml` file to define the products' API service.
- Add `.env.dev` to pass environment variables to the products API service's container.